### PR TITLE
Support Az.Monitor 7.0.0 plain-string output shape

### DIFF
--- a/src/ConvertFrom-AzActivityLogRecord.ps1
+++ b/src/ConvertFrom-AzActivityLogRecord.ps1
@@ -32,8 +32,9 @@ function ConvertFrom-AzActivityLogRecord {
     # - The principal cannot be resolved (no ObjectId, AppId, or Caller).
     # - The action string is null or whitespace after normalization.
     # .NOTES
-    # Requires ConvertFrom-ClaimsJson, Resolve-PrincipalKey, and
-    # ConvertTo-NormalizedAction to be loaded.
+    # Requires ConvertFrom-ClaimsJson, Resolve-PrincipalKey,
+    # Resolve-LocalizableStringValue, and ConvertTo-NormalizedAction to be
+    # loaded.
     #
     # Supported on Windows PowerShell 5.1 (.NET Framework 4.6.2+) and
     # PowerShell 7.4.x / 7.5.x / 7.6.x (Windows, macOS, Linux).
@@ -41,7 +42,7 @@ function ConvertFrom-AzActivityLogRecord {
     # This function supports positional parameters:
     #   Position 0: Record
     #
-    # Version: 1.1.20260412.0
+    # Version: 1.2.20260413.0
 
     [CmdletBinding()]
     [OutputType([pscustomobject])]
@@ -105,8 +106,20 @@ function ConvertFrom-AzActivityLogRecord {
             $strActionRaw = $null
             if ($null -ne $Record.Authorization -and $null -ne $Record.Authorization.Action) {
                 $strActionRaw = [string]$Record.Authorization.Action
-            } elseif ($null -ne $Record.OperationName -and $null -ne $Record.OperationName.Value) {
-                $strActionRaw = [string]$Record.OperationName.Value
+            } else {
+                # Az.Monitor <=6 returned OperationName as a PSLocalizedString
+                # whose .Value was an RBAC action id (e.g.
+                # 'Microsoft.Compute/virtualMachines/read'). Az.Monitor 7+
+                # returns OperationName as a plain [string] holding the
+                # friendly display name (e.g. 'Delete role assignment').
+                # Resolve the shape first, then only accept it as a
+                # fallback action when it resembles an RBAC action id; an
+                # unqualified display name would pollute the clustering
+                # pipeline with non-actions.
+                $strOperationName = Resolve-LocalizableStringValue -InputObject $Record.OperationName
+                if (-not [string]::IsNullOrWhiteSpace($strOperationName) -and $strOperationName.Contains('/')) {
+                    $strActionRaw = $strOperationName
+                }
             }
 
             $strAction = ConvertTo-NormalizedAction -Action $strActionRaw
@@ -123,6 +136,10 @@ function ConvertFrom-AzActivityLogRecord {
             if ($boolVerbose) {
                 Write-Verbose "Emitting CanonicalAdminEvent object."
             }
+            # Status is a PSLocalizedString in older Az.Monitor (needs
+            # .Value) and a plain [string] in Az.Monitor 7+. Normalize both.
+            $strStatus = Resolve-LocalizableStringValue -InputObject $Record.Status
+
             [pscustomobject]@{
                 PSTypeName = 'CanonicalAdminEvent'
                 TimeGenerated = $Record.EventTimestamp
@@ -130,7 +147,7 @@ function ConvertFrom-AzActivityLogRecord {
                 PrincipalKey = [string]$objPrincipal.Key
                 PrincipalType = [string]$objPrincipal.Type
                 Action = $strAction
-                Status = $Record.Status.Value
+                Status = $strStatus
                 ResourceId = $Record.ResourceId
                 CorrelationId = $Record.CorrelationId
                 Caller = $Record.Caller

--- a/src/GloryRole.psd1
+++ b/src/GloryRole.psd1
@@ -37,6 +37,7 @@
         'New-FeatureIndex'
         'Remove-DuplicateCanonicalEvent'
         'Remove-RareAction'
+        'Resolve-LocalizableStringValue'
         'Resolve-PrincipalKey'
     )
 

--- a/src/GloryRole.psd1
+++ b/src/GloryRole.psd1
@@ -8,7 +8,7 @@
     Description       = 'An unsupervised role mining engine written in PowerShell. Feed it cloud activity logs and it figures out who does what, groups similar principals via K-Means clustering, and generates least-privilege custom role definitions.'
     PowerShellVersion = '5.1'
 
-    # Functions to export — these are the 27 function files in src/
+    # Functions to export — these are the 28 function files in src/
     # (excludes Invoke-RoleMiningPipeline.ps1 which is a script entry point)
     FunctionsToExport = @(
         'ConvertFrom-AzActivityLogRecord'

--- a/src/Invoke-RoleMiningPipeline.ps1
+++ b/src/Invoke-RoleMiningPipeline.ps1
@@ -138,7 +138,7 @@
 # Position 1: OutputPath
 # All remaining parameters should be specified by name.
 #
-# Version: 1.2.20260410.0
+# Version: 1.3.20260413.0
 
 [CmdletBinding()]
 [OutputType([pscustomobject])]
@@ -187,6 +187,7 @@ $strScriptDirectory = $PSScriptRoot
 . (Join-Path -Path $strScriptDirectory -ChildPath 'Resolve-PrincipalKey.ps1')
 . (Join-Path -Path $strScriptDirectory -ChildPath 'Get-StableSha256Hex.ps1')
 . (Join-Path -Path $strScriptDirectory -ChildPath 'ConvertFrom-ClaimsJson.ps1')
+. (Join-Path -Path $strScriptDirectory -ChildPath 'Resolve-LocalizableStringValue.ps1')
 . (Join-Path -Path $strScriptDirectory -ChildPath 'ConvertFrom-AzActivityLogRecord.ps1')
 . (Join-Path -Path $strScriptDirectory -ChildPath 'Get-AzActivityAdminEvent.ps1')
 . (Join-Path -Path $strScriptDirectory -ChildPath 'Import-PrincipalActionCountFromLogAnalytics.ps1')

--- a/src/Resolve-LocalizableStringValue.ps1
+++ b/src/Resolve-LocalizableStringValue.ps1
@@ -38,8 +38,17 @@ function Resolve-LocalizableStringValue {
     # .INPUTS
     # None. You cannot pipe objects to this function.
     # .OUTPUTS
-    # [string] The resolved text value. Returns $null when the input is
-    # $null or is an object that exposes neither .Value nor .LocalizedValue.
+    # [string] The resolved text value. Returns $null in any of the
+    # following cases, so callers can distinguish "absent" from "present
+    # but empty":
+    #   - The input is $null.
+    #   - The input is an object that exposes neither .Value nor
+    #     .LocalizedValue.
+    #   - The input is an object whose .Value and .LocalizedValue
+    #     properties both exist but have a $null underlying value.
+    # Returns the empty string '' (not $null) when the input is itself
+    # an empty [string], because that case is a present-but-empty value
+    # rather than an absent one.
     # .NOTES
     # Supported PowerShell versions:
     #   - Windows PowerShell 5.1 (.NET Framework 4.6.2+)
@@ -54,7 +63,7 @@ function Resolve-LocalizableStringValue {
     # This function supports positional parameters:
     #   Position 0: InputObject
     #
-    # Version: 1.0.20260413.0
+    # Version: 1.0.20260413.1
 
     [CmdletBinding()]
     [OutputType([string])]

--- a/src/Resolve-LocalizableStringValue.ps1
+++ b/src/Resolve-LocalizableStringValue.ps1
@@ -63,7 +63,7 @@ function Resolve-LocalizableStringValue {
     # This function supports positional parameters:
     #   Position 0: InputObject
     #
-    # Version: 1.0.20260413.1
+    # Version: 1.0.20260413.2
 
     [CmdletBinding()]
     [OutputType([string])]
@@ -81,10 +81,10 @@ function Resolve-LocalizableStringValue {
                 return [string]$InputObject
             }
 
-            # Guard PSObject access so non-PSObject primitive/value types
-            # fall through to the $null return rather than throwing under
-            # Set-StrictMode -Version Latest.
-            if ($null -ne $InputObject.PSObject -and $null -ne $InputObject.PSObject.Properties) {
+            # Probe for Value/LocalizedValue properties before reading them
+            # so inputs that do not expose either member fall through to the
+            # $null return instead of throwing under Set-StrictMode -Version Latest.
+            if ($null -ne $InputObject.PSObject.Properties) {
                 if ($InputObject.PSObject.Properties['Value']) {
                     $objInner = $InputObject.Value
                     if ($null -ne $objInner) {

--- a/src/Resolve-LocalizableStringValue.ps1
+++ b/src/Resolve-LocalizableStringValue.ps1
@@ -1,0 +1,99 @@
+Set-StrictMode -Version Latest
+
+function Resolve-LocalizableStringValue {
+    # .SYNOPSIS
+    # Normalizes a "localizable string" field from Azure PowerShell output.
+    # .DESCRIPTION
+    # Azure PowerShell historically returned many string-like fields (for
+    # example Status, Category, and OperationName on activity log records)
+    # as PSObject values exposing .Value and .LocalizedValue properties.
+    # Starting with Az.Monitor 7.0.0, those same fields are returned as
+    # plain [string] values, which causes $field.Value reads to fail under
+    # Set-StrictMode -Version Latest.
+    #
+    # This helper accepts any of those shapes and returns a single
+    # [string] result suitable for downstream string processing. Inputs of
+    # any other shape are treated as unresolvable and produce $null.
+    # .PARAMETER InputObject
+    # The field value to normalize. May be $null, a [string], or a
+    # PSObject exposing a .Value or .LocalizedValue property.
+    # .EXAMPLE
+    # $strResult = Resolve-LocalizableStringValue -InputObject 'Succeeded'
+    # # $strResult = 'Succeeded'
+    #
+    # # Plain strings (the Az.Monitor 7+ shape) pass through unchanged.
+    # .EXAMPLE
+    # $objLegacy = [pscustomobject]@{ Value = 'Succeeded'; LocalizedValue = 'Succeeded' }
+    # $strResult = Resolve-LocalizableStringValue -InputObject $objLegacy
+    # # $strResult = 'Succeeded'
+    #
+    # # Legacy Az.Monitor PSLocalizedString objects are reduced to their
+    # # .Value, which holds the non-localized canonical value.
+    # .EXAMPLE
+    # $strResult = Resolve-LocalizableStringValue -InputObject $null
+    # # $strResult = $null
+    #
+    # # A $null input returns $null rather than an empty string, so callers
+    # # can distinguish "absent" from "present but empty".
+    # .INPUTS
+    # None. You cannot pipe objects to this function.
+    # .OUTPUTS
+    # [string] The resolved text value. Returns $null when the input is
+    # $null or is an object that exposes neither .Value nor .LocalizedValue.
+    # .NOTES
+    # Supported PowerShell versions:
+    #   - Windows PowerShell 5.1 (.NET Framework 4.6.2+)
+    #   - PowerShell 7.4.x
+    #   - PowerShell 7.5.x
+    #   - PowerShell 7.6.x
+    # Supported operating systems:
+    #   - Windows (Windows PowerShell 5.1 and PowerShell 7.x)
+    #   - macOS (PowerShell 7.x only)
+    #   - Linux (PowerShell 7.x only)
+    #
+    # This function supports positional parameters:
+    #   Position 0: InputObject
+    #
+    # Version: 1.0.20260413.0
+
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [object]$InputObject
+    )
+
+    process {
+        try {
+            if ($null -eq $InputObject) {
+                return $null
+            }
+
+            if ($InputObject -is [string]) {
+                return [string]$InputObject
+            }
+
+            # Guard PSObject access so non-PSObject primitive/value types
+            # fall through to the $null return rather than throwing under
+            # Set-StrictMode -Version Latest.
+            if ($null -ne $InputObject.PSObject -and $null -ne $InputObject.PSObject.Properties) {
+                if ($InputObject.PSObject.Properties['Value']) {
+                    $objInner = $InputObject.Value
+                    if ($null -ne $objInner) {
+                        return [string]$objInner
+                    }
+                }
+                if ($InputObject.PSObject.Properties['LocalizedValue']) {
+                    $objInner = $InputObject.LocalizedValue
+                    if ($null -ne $objInner) {
+                        return [string]$objInner
+                    }
+                }
+            }
+
+            return $null
+        } catch {
+            Write-Debug ("Resolve-LocalizableStringValue failed: {0}" -f $_.Exception.Message)
+            throw
+        }
+    }
+}

--- a/tests/PowerShell/ConvertFrom-AzActivityLogRecord.Tests.ps1
+++ b/tests/PowerShell/ConvertFrom-AzActivityLogRecord.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     $strSrcPath = Join-Path -Path $strRepoRoot -ChildPath 'src'
     . (Join-Path -Path $strSrcPath -ChildPath 'ConvertFrom-ClaimsJson.ps1')
     . (Join-Path -Path $strSrcPath -ChildPath 'Resolve-PrincipalKey.ps1')
+    . (Join-Path -Path $strSrcPath -ChildPath 'Resolve-LocalizableStringValue.ps1')
     . (Join-Path -Path $strSrcPath -ChildPath 'ConvertTo-NormalizedAction.ps1')
     . (Join-Path -Path $strSrcPath -ChildPath 'ConvertFrom-AzActivityLogRecord.ps1')
 }
@@ -214,6 +215,140 @@ Describe "ConvertFrom-AzActivityLogRecord" {
             $objResult.Caller | Should -Be 'external-caller@partner.com'
             $objResult.PrincipalUPN | Should -Be $null
             $objResult.AppId | Should -Be $null
+        }
+    }
+
+    # The following contexts cover the Az.Monitor 7.0.0 output shape, where
+    # Status and OperationName are emitted as plain [string] values rather
+    # than PSLocalizedString objects with .Value / .LocalizedValue.
+    Context "When the record uses the Az.Monitor 7 plain-string Status shape" {
+        It "Reads Status as a plain string and still emits a CanonicalAdminEvent" {
+            # Arrange
+            $objRecord = [pscustomobject]@{
+                Category = 'Administrative'
+                Claims = '{"http://schemas.microsoft.com/identity/claims/objectidentifier":"oid-v7"}'
+                Authorization = [pscustomobject]@{ Action = 'Microsoft.Authorization/roleAssignments/delete' }
+                OperationName = 'Delete role assignment'
+                Caller = '4555631e-1459-47a7-bf60-b53ebc3670e4'
+                EventTimestamp = (Get-Date)
+                SubscriptionId = 'sub-v7'
+                Status = 'Succeeded'
+                ResourceId = '/subscriptions/sub-v7/providers/Microsoft.Authorization/roleAssignments/ra-1'
+                CorrelationId = 'corr-v7'
+            }
+
+            # Act
+            $objResult = ConvertFrom-AzActivityLogRecord -Record $objRecord
+
+            # Assert
+            $objResult | Should -Not -BeNullOrEmpty
+            $objResult.Status | Should -Be 'Succeeded'
+            $objResult.Action | Should -Be 'microsoft.authorization/roleassignments/delete'
+        }
+    }
+
+    Context "When Status exposes only LocalizedValue" {
+        It "Falls back to LocalizedValue when Value is absent" {
+            # Arrange
+            $objRecord = [pscustomobject]@{
+                Category = 'Administrative'
+                Claims = '{"http://schemas.microsoft.com/identity/claims/objectidentifier":"oid-loc"}'
+                Authorization = [pscustomobject]@{ Action = 'Microsoft.Storage/storageAccounts/read' }
+                OperationName = $null
+                Caller = 'user@example.com'
+                EventTimestamp = (Get-Date)
+                SubscriptionId = 'sub-loc'
+                Status = [pscustomobject]@{ LocalizedValue = 'Succeeded' }
+                ResourceId = '/subscriptions/sub-loc'
+                CorrelationId = 'corr-loc'
+            }
+
+            # Act
+            $objResult = ConvertFrom-AzActivityLogRecord -Record $objRecord
+
+            # Assert
+            $objResult.Status | Should -Be 'Succeeded'
+        }
+    }
+
+    Context "When Status is null" {
+        It "Emits a CanonicalAdminEvent with Status = `$null without throwing" {
+            # Arrange
+            $objRecord = [pscustomobject]@{
+                Category = 'Administrative'
+                Claims = '{"http://schemas.microsoft.com/identity/claims/objectidentifier":"oid-nostatus"}'
+                Authorization = [pscustomobject]@{ Action = 'Microsoft.Resources/subscriptions/read' }
+                OperationName = $null
+                Caller = 'user@example.com'
+                EventTimestamp = (Get-Date)
+                SubscriptionId = 'sub-nostatus'
+                Status = $null
+                ResourceId = '/subscriptions/sub-nostatus'
+                CorrelationId = 'corr-nostatus'
+            }
+
+            # Act
+            $objResult = ConvertFrom-AzActivityLogRecord -Record $objRecord
+
+            # Assert
+            $objResult | Should -Not -BeNullOrEmpty
+            $objResult.Status | Should -Be $null
+        }
+    }
+
+    Context "When Authorization is null and OperationName is the Az.Monitor 7 friendly display name" {
+        It "Returns null rather than using a non-action display name" {
+            # Arrange
+            # In Az.Monitor 7+, OperationName carries the friendly display
+            # name ("Delete role assignment") instead of an RBAC action id.
+            # Feeding that into the clustering pipeline as if it were an
+            # action would produce garbage, so records without a usable
+            # Authorization.Action MUST be dropped.
+            $objRecord = [pscustomobject]@{
+                Category = 'Administrative'
+                Claims = '{"http://schemas.microsoft.com/identity/claims/objectidentifier":"oid-display"}'
+                Authorization = $null
+                OperationName = 'Delete role assignment'
+                Caller = 'user@example.com'
+                EventTimestamp = (Get-Date)
+                SubscriptionId = 'sub-display'
+                Status = 'Succeeded'
+                ResourceId = '/subscriptions/sub-display'
+                CorrelationId = 'corr-display'
+            }
+
+            # Act
+            $objResult = ConvertFrom-AzActivityLogRecord -Record $objRecord
+
+            # Assert
+            $objResult | Should -Be $null
+        }
+    }
+
+    Context "When Authorization is null and OperationName is a plain-string action id" {
+        It "Accepts the plain-string OperationName as the action" {
+            # Arrange
+            # Az.Monitor 7 still returns a plain [string] for OperationName;
+            # when that string happens to look like an RBAC action id
+            # (contains '/'), it is a valid fallback.
+            $objRecord = [pscustomobject]@{
+                Category = 'Administrative'
+                Claims = '{"http://schemas.microsoft.com/identity/claims/objectidentifier":"oid-plain"}'
+                Authorization = $null
+                OperationName = 'Microsoft.Resources/subscriptions/read'
+                Caller = 'user@example.com'
+                EventTimestamp = (Get-Date)
+                SubscriptionId = 'sub-plain'
+                Status = 'Succeeded'
+                ResourceId = '/subscriptions/sub-plain'
+                CorrelationId = 'corr-plain'
+            }
+
+            # Act
+            $objResult = ConvertFrom-AzActivityLogRecord -Record $objRecord
+
+            # Assert
+            $objResult.Action | Should -Be 'microsoft.resources/subscriptions/read'
         }
     }
 }

--- a/tests/PowerShell/Get-AzActivityAdminEvent.Tests.ps1
+++ b/tests/PowerShell/Get-AzActivityAdminEvent.Tests.ps1
@@ -5,6 +5,7 @@ BeforeAll {
 
     . (Join-Path -Path $strSrcPath -ChildPath 'ConvertFrom-ClaimsJson.ps1')
     . (Join-Path -Path $strSrcPath -ChildPath 'Resolve-PrincipalKey.ps1')
+    . (Join-Path -Path $strSrcPath -ChildPath 'Resolve-LocalizableStringValue.ps1')
     . (Join-Path -Path $strSrcPath -ChildPath 'ConvertTo-NormalizedAction.ps1')
     . (Join-Path -Path $strSrcPath -ChildPath 'ConvertFrom-AzActivityLogRecord.ps1')
     . (Join-Path -Path $strSrcPath -ChildPath 'Get-AzActivityAdminEvent.ps1')

--- a/tests/PowerShell/Resolve-LocalizableStringValue.Tests.ps1
+++ b/tests/PowerShell/Resolve-LocalizableStringValue.Tests.ps1
@@ -69,6 +69,23 @@ Describe "Resolve-LocalizableStringValue" {
         }
     }
 
+    Context "When the input is a PSObject whose LocalizedValue is null" {
+        It "Returns null when LocalizedValue exists but its underlying value is `$null" {
+            # Arrange
+            # This locks in the $null-vs-empty-string contract for the
+            # LocalizedValue fallback path: a present-but-null property
+            # must resolve to $null rather than the empty string produced
+            # by a naive [string]$null cast.
+            $objInput = [pscustomobject]@{ LocalizedValue = $null }
+
+            # Act
+            $strResult = Resolve-LocalizableStringValue -InputObject $objInput
+
+            # Assert
+            $strResult | Should -Be $null
+        }
+    }
+
     Context "When the input is a PSObject whose Value is null" {
         It "Returns null rather than the empty string from a null cast" {
             # Arrange

--- a/tests/PowerShell/Resolve-LocalizableStringValue.Tests.ps1
+++ b/tests/PowerShell/Resolve-LocalizableStringValue.Tests.ps1
@@ -1,0 +1,107 @@
+BeforeAll {
+    # Avoid relative-path segments per style guide checklist item
+    $strRepoRoot = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent
+    $strSrcPath = Join-Path -Path $strRepoRoot -ChildPath 'src'
+    . (Join-Path -Path $strSrcPath -ChildPath 'Resolve-LocalizableStringValue.ps1')
+}
+
+Describe "Resolve-LocalizableStringValue" {
+    Context "When the input is null" {
+        It "Returns null" {
+            # Arrange, Act
+            $strResult = Resolve-LocalizableStringValue -InputObject $null
+
+            # Assert
+            $strResult | Should -Be $null
+        }
+    }
+
+    Context "When the input is a plain string (Az.Monitor 7+ shape)" {
+        It "Returns the string unchanged" {
+            # Arrange
+            $strInput = 'Succeeded'
+
+            # Act
+            $strResult = Resolve-LocalizableStringValue -InputObject $strInput
+
+            # Assert
+            $strResult | Should -Be 'Succeeded'
+        }
+
+        It "Returns an empty string as-is (distinguishable from null)" {
+            # Arrange, Act
+            $strResult = Resolve-LocalizableStringValue -InputObject ''
+
+            # Assert
+            $strResult | Should -Be ''
+            $strResult | Should -Not -Be $null
+        }
+    }
+
+    Context "When the input is a PSObject with Value (legacy Az.Monitor shape)" {
+        It "Returns the Value property" {
+            # Arrange
+            $objInput = [pscustomobject]@{
+                Value = 'Succeeded'
+                LocalizedValue = 'Succeeded (localized)'
+            }
+
+            # Act
+            $strResult = Resolve-LocalizableStringValue -InputObject $objInput
+
+            # Assert
+            # Value is preferred over LocalizedValue because Value holds
+            # the non-localized canonical form used by downstream logic.
+            $strResult | Should -Be 'Succeeded'
+        }
+    }
+
+    Context "When the input is a PSObject with only LocalizedValue" {
+        It "Falls back to LocalizedValue" {
+            # Arrange
+            $objInput = [pscustomobject]@{ LocalizedValue = 'Administrative' }
+
+            # Act
+            $strResult = Resolve-LocalizableStringValue -InputObject $objInput
+
+            # Assert
+            $strResult | Should -Be 'Administrative'
+        }
+    }
+
+    Context "When the input is a PSObject whose Value is null" {
+        It "Returns null rather than the empty string from a null cast" {
+            # Arrange
+            $objInput = [pscustomobject]@{ Value = $null }
+
+            # Act
+            $strResult = Resolve-LocalizableStringValue -InputObject $objInput
+
+            # Assert
+            $strResult | Should -Be $null
+        }
+    }
+
+    Context "When the input is a PSObject with neither Value nor LocalizedValue" {
+        It "Returns null" {
+            # Arrange
+            $objInput = [pscustomobject]@{ Other = 'irrelevant' }
+
+            # Act
+            $strResult = Resolve-LocalizableStringValue -InputObject $objInput
+
+            # Assert
+            $strResult | Should -Be $null
+        }
+    }
+
+    Context "When the input is a value type without PSObject properties" {
+        It "Returns null for an integer" {
+            # Arrange, Act
+            $strResult = Resolve-LocalizableStringValue -InputObject 42
+
+            # Assert
+            $strResult | Should -Be $null
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR adds support for Azure PowerShell&#39;s Az.Monitor 7.0.0 output format, which changed how string-like fields (Status, Category, OperationName) are returned. Previously, these fields were PSLocalizedString objects with `.Value` and `.LocalizedValue` properties. Az.Monitor 7+ returns them as plain `[string]` values, which causes property access to fail under `Set-StrictMode -Version Latest`.

### Changes

1. **New helper function: `Resolve-LocalizableStringValue`**
   - Normalizes &#34;localizable string&#34; fields from Azure PowerShell output
   - Handles three input shapes: `$null`, plain `[string]`, and PSObject with `.Value`/`.LocalizedValue` properties
   - Returns a single `[string]` result suitable for downstream processing
   - Includes comprehensive unit tests covering all input shapes

2. **Updated `ConvertFrom-AzActivityLogRecord`**
   - Uses `Resolve-LocalizableStringValue` to normalize the `Status` field
   - Improved `OperationName` fallback logic: now resolves the shape first, then validates that it resembles an RBAC action ID (contains &#39;/&#39;) before using it as a fallback action
   - This prevents friendly display names (e.g., &#34;Delete role assignment&#34;) from polluting the clustering pipeline
   - Updated version and documentation

3. **Test coverage**
   - Added 5 new test contexts in `ConvertFrom-AzActivityLogRecord.Tests.ps1` covering:
     - Plain-string Status shape (Az.Monitor 7)
     - Status with only LocalizedValue (fallback behavior)
     - Null Status handling
     - Authorization-null + OperationName-as-display-name (record dropped)
     - Authorization-null + OperationName-as-action-id (accepted)
   - Added unit tests for `Resolve-LocalizableStringValue` (8 `It` blocks covering `$null`, plain string, empty string, legacy PSObject with both `.Value` and `.LocalizedValue`, `LocalizedValue`-only, present-but-null `.Value`, object with neither property, and value-type inputs)

4. **Module exports**
   - Added `Resolve-LocalizableStringValue` to the module&#39;s exported functions list

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

### General

- [x] My code follows the coding standards in `.github/instructions/`
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have added or updated tests where appropriate
- [x] New and existing tests pass locally

### PowerShell-Specific

- [x] Pester tests pass locally (13 new test cases: 5 integration contexts plus 8 helper unit tests)
- [x] PowerShell formatting follows repository standards (OTBS)

## Additional Notes

The changes are backward compatible with older Az.Monitor versions (&lt;=6) while adding support for the new plain-string shape in Az.Monitor 7+. The logic gracefully handles both formats without requiring version detection.

https://claude.ai/code/session_0181QBfbUe3eCHdVv64U4fH8