### PR TITLE
Add -RoleSchema parameter to decouple data source from output schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,44 @@ GloryRole implements a complete end-to-end pipeline in ten stages:
 
 ## Quick Start
 
+`Invoke-RoleMiningPipeline.ps1` takes two required parameters that describe independent concerns:
+
+- `-InputMode` selects the **data source** (where the principal-action counts come from): `CSV`, `ActivityLog`, `LogAnalytics`, or `EntraId`.
+- `-RoleSchema` selects the **role-definition schema** to emit: `AzureRbac` or `EntraId`.
+
+`-RoleSchema` is **required** when the source is schema-neutral (`CSV`, `LogAnalytics`) and **defaulted** when the source is schema-constrained (`ActivityLog` → `AzureRbac`; `EntraId` → `EntraId`). Incompatible combinations (e.g., `-InputMode EntraId -RoleSchema AzureRbac`) fail fast with a clear error.
+
 ```powershell
-# From a local CSV sample
+# From a local CSV sample — Azure RBAC output
 .\src\Invoke-RoleMiningPipeline.ps1 -InputMode CSV `
     -CsvPath .\samples\principal_action_counts.csv `
+    -RoleSchema AzureRbac `
     -OutputPath .\output
 
+# From a local Entra ID CSV sample — Entra custom role output
+.\src\Invoke-RoleMiningPipeline.ps1 -InputMode CSV `
+    -CsvPath .\samples\entra_id_principal_action_counts.csv `
+    -RoleSchema EntraId `
+    -OutputPath .\output\entra-demo
+
 # From Azure Activity Log (requires Az module)
+# RoleSchema defaults to AzureRbac for this source; can be omitted.
 .\src\Invoke-RoleMiningPipeline.ps1 -InputMode ActivityLog `
     -SubscriptionIds @('your-sub-id') `
     -Start (Get-Date).AddDays(-90) -End (Get-Date) `
     -OutputPath .\output
 
 # From Log Analytics (requires Az.OperationalInsights)
+# A Log Analytics workspace can hold either Azure Activity or Entra
+# tables, so RoleSchema is required.
 .\src\Invoke-RoleMiningPipeline.ps1 -InputMode LogAnalytics `
     -WorkspaceId 'your-workspace-id' `
+    -RoleSchema AzureRbac `
     -Start (Get-Date).AddDays(-90) -End (Get-Date) `
     -OutputPath .\output
 
 # From Entra ID audit logs (requires Microsoft.Graph.Reports)
+# RoleSchema defaults to EntraId for this source; can be omitted.
 Connect-MgGraph -Scopes 'AuditLog.Read.All'
 .\src\Invoke-RoleMiningPipeline.ps1 -InputMode EntraId `
     -Start (Get-Date).AddDays(-90) -End (Get-Date) `
@@ -64,12 +83,11 @@ Connect-MgGraph -Scopes 'AuditLog.Read.All'
     -Start (Get-Date).AddDays(-90) -End (Get-Date) `
     -EntraIdFilterCategory @('GroupManagement', 'UserManagement') `
     -OutputPath .\output\entra
-
-# From Entra ID sample CSV (for demos/testing)
-.\src\Invoke-RoleMiningPipeline.ps1 -InputMode CSV `
-    -CsvPath .\samples\entra_id_principal_action_counts.csv `
-    -OutputPath .\output\entra-demo
 ```
+
+### Migration note — breaking change in 1.8
+
+Prior versions silently routed all non-`EntraId` modes to Azure RBAC output. Starting in `Invoke-RoleMiningPipeline.ps1` **1.8**, `-RoleSchema` must be supplied explicitly for schema-neutral sources (`CSV`, `LogAnalytics`). The previous behavior treated Azure RBAC as the implicit default, which made no principled sense for CSV/LogAnalytics inputs that could equally hold Entra, and which also would not extend cleanly as AWS IAM, GCP IAM, and Active Directory schemas are added. Existing `CSV` or `LogAnalytics` invocations must be updated to pass `-RoleSchema AzureRbac` (for the previous behavior) or `-RoleSchema EntraId` (for Entra custom roles). `ActivityLog` and `EntraId` invocations are unaffected.
 
 ## Output Artifacts
 
@@ -80,8 +98,8 @@ Connect-MgGraph -Scopes 'AuditLog.Read.All'
 | `quality.json` | Dataset quality metrics (principals, actions, density) |
 | `autoK_candidates.csv` | Every evaluated K with all metrics, ranks, and composite score |
 | `clusters.json` | Cluster-to-action mapping with principal lists |
-| `role_cluster_<id>.json` | One Azure custom role definition per cluster (RBAC modes) |
-| `entra_role_cluster_<id>.json` | One Entra ID custom role definition per cluster (EntraId mode) |
+| `role_cluster_<id>.json` | One Azure custom role definition per cluster (when `-RoleSchema AzureRbac`) |
+| `entra_role_cluster_<id>.json` | One Entra ID custom role definition per cluster (when `-RoleSchema EntraId`) |
 
 ## Who It's For
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ GloryRole implements a complete end-to-end pipeline in ten stages:
 
 ## Quick Start
 
-`Invoke-RoleMiningPipeline.ps1` takes two required parameters that describe independent concerns:
+`Invoke-RoleMiningPipeline.ps1` has two key parameters that describe independent concerns:
 
 - `-InputMode` selects the **data source** (where the principal-action counts come from): `CSV`, `ActivityLog`, `LogAnalytics`, or `EntraId`.
-- `-RoleSchema` selects the **role-definition schema** to emit: `AzureRbac` or `EntraId`.
+- `-RoleSchema` selects the **role-definition schema** to emit: `AzureRbac` or `EntraId`; it is **required** for schema-neutral sources and **defaulted** for schema-constrained sources.
 
 `-RoleSchema` is **required** when the source is schema-neutral (`CSV`, `LogAnalytics`) and **defaulted** when the source is schema-constrained (`ActivityLog` → `AzureRbac`; `EntraId` → `EntraId`). Incompatible combinations (e.g., `-InputMode EntraId -RoleSchema AzureRbac`) fail fast with a clear error.
 

--- a/docs/spec/requirements.md
+++ b/docs/spec/requirements.md
@@ -222,16 +222,26 @@ Used when ingesting Entra ID directory audit logs via Microsoft Graph API. A
   from the original (pre-vectorization) sparse triples.
   - **Verification:** Unit test.
 
-- **REQ-ROL-002:** The system MUST emit valid Azure custom role definition JSON
-  with `Name`, `IsCustom`, `Description`, `Actions`, `NotActions`,
-  `DataActions`, `NotDataActions`, and `AssignableScopes`.
+- **REQ-ROL-002:** When `RoleSchema` resolves to `AzureRbac`, the system MUST
+  emit valid Azure custom role definition JSON with `Name`, `IsCustom`,
+  `Description`, `Actions`, `NotActions`, `DataActions`, `NotDataActions`,
+  and `AssignableScopes`.
   - **Verification:** Unit test.
 
-- **REQ-ROL-003:** When InputMode is `EntraId`, the system MUST emit valid
-  Entra ID custom role definition JSON in the `unifiedRoleDefinition` format
-  with `displayName`, `description`, `isEnabled`, and `rolePermissions`
-  containing `allowedResourceActions` in the `microsoft.directory/*`
-  namespace.
+- **REQ-ROL-003:** When `RoleSchema` resolves to `EntraId`, the system MUST
+  emit valid Entra ID custom role definition JSON in the
+  `unifiedRoleDefinition` format with `displayName`, `description`,
+  `isEnabled`, and `rolePermissions` containing `allowedResourceActions`
+  in the `microsoft.directory/*` namespace.
+  - **Verification:** Unit test.
+
+- **REQ-ROL-004:** `InputMode` (data source) and `RoleSchema` (output role
+  schema) are independent concerns. `RoleSchema` defaults where the source
+  is schema-constrained (`ActivityLog` → `AzureRbac`; `EntraId` → `EntraId`)
+  and is required for schema-neutral sources (`CSV`, `LogAnalytics`). The
+  tool MUST NOT assume a default platform for schema-neutral inputs.
+  Incompatible combinations (e.g., `InputMode EntraId` with
+  `RoleSchema AzureRbac`) MUST fail fast with an actionable error.
   - **Verification:** Unit test.
 
 ### Export

--- a/src/Invoke-RoleMiningPipeline.ps1
+++ b/src/Invoke-RoleMiningPipeline.ps1
@@ -8,8 +8,35 @@
 # export all artifacts.
 #
 # .PARAMETER InputMode
-# Mandatory. Selects the data ingestion mode. Valid values are 'CSV',
-# 'ActivityLog', 'LogAnalytics', and 'EntraId'.
+# Mandatory. Selects the **data source** (where the principal-action
+# counts come from). Valid values are 'CSV', 'ActivityLog',
+# 'LogAnalytics', and 'EntraId'. This parameter describes the shape
+# of the input only and is **independent** of which role-definition
+# schema the pipeline emits at the end; see RoleSchema.
+#
+# .PARAMETER RoleSchema
+# Selects the **role-definition schema** written to the per-cluster
+# role JSON artifacts. Valid values are 'AzureRbac' (Azure RBAC
+# `roleDefinition` JSON with `Actions` / `AssignableScopes`) and
+# 'EntraId' (Microsoft Graph `unifiedRoleDefinition` JSON with
+# `rolePermissions.allowedResourceActions` in the
+# `microsoft.directory/*` namespace).
+#
+# For **schema-neutral** data sources, `RoleSchema` is **required**
+# because the tool does not assume a default platform:
+#   - InputMode 'CSV': the CSV is a neutral container; caller must
+#     pass `-RoleSchema AzureRbac` or `-RoleSchema EntraId`.
+#   - InputMode 'LogAnalytics': workspaces can hold Azure Activity,
+#     Entra sign-in / audit logs, or custom tables; caller must
+#     pass the matching schema.
+# For **schema-constrained** data sources, `RoleSchema` defaults
+# (and passing an incompatible value throws):
+#   - InputMode 'ActivityLog' (Azure Activity Log cmdlet) defaults
+#     to 'AzureRbac'.
+#   - InputMode 'EntraId' (Microsoft Graph directory audit logs)
+#     defaults to 'EntraId'.
+# Artifact naming: 'AzureRbac' produces `role_cluster_<id>.json`;
+# 'EntraId' produces `entra_role_cluster_<id>.json`.
 #
 # .PARAMETER OutputPath
 # Mandatory. Directory where all artifacts are exported. Created
@@ -117,25 +144,35 @@
 #     exported
 #
 # .EXAMPLE
-# $objResult = & (Join-Path -Path $HOME -ChildPath 'repos/GloryRole/src/Invoke-RoleMiningPipeline.ps1') -InputMode CSV -CsvPath (Join-Path -Path $HOME -ChildPath 'data/counts.csv') -OutputPath (Join-Path -Path $HOME -ChildPath 'output/role-mining')
+# $objResult = & (Join-Path -Path $HOME -ChildPath 'repos/GloryRole/src/Invoke-RoleMiningPipeline.ps1') -InputMode CSV -CsvPath (Join-Path -Path $HOME -ChildPath 'data/counts.csv') -RoleSchema AzureRbac -OutputPath (Join-Path -Path $HOME -ChildPath 'output/role-mining')
 #
-# # Runs the pipeline in CSV mode. The returned object contains
-# # RecommendedK, Candidates, ClusterActions, Quality, and OutputPath
-# # properties summarizing the role-mining results.
+# # Runs the pipeline in CSV mode with Azure RBAC output. The returned
+# # object contains RecommendedK, Candidates, ClusterActions, Quality,
+# # and OutputPath properties summarizing the role-mining results.
+# # Emits role_cluster_<id>.json per cluster.
+#
+# .EXAMPLE
+# $objResult = & (Join-Path -Path $HOME -ChildPath 'repos/GloryRole/src/Invoke-RoleMiningPipeline.ps1') -InputMode CSV -CsvPath (Join-Path -Path $HOME -ChildPath 'data/entra_counts.csv') -RoleSchema EntraId -OutputPath (Join-Path -Path $HOME -ChildPath 'output/entra-role-mining')
+#
+# # Runs the pipeline in CSV mode with Entra ID output. Useful for
+# # demos and offline testing with a pre-canonicalized Entra sparse
+# # triple CSV. Emits entra_role_cluster_<id>.json per cluster.
 #
 # .EXAMPLE
 # $objResult = & (Join-Path -Path $HOME -ChildPath 'repos/GloryRole/src/Invoke-RoleMiningPipeline.ps1') -InputMode ActivityLog -SubscriptionIds @('00000000-0000-0000-0000-000000000001') -Start (Get-Date).AddDays(-30) -End (Get-Date) -OutputPath (Join-Path -Path $HOME -ChildPath 'output/role-mining')
 #
 # # Runs the pipeline in ActivityLog mode. Queries the Azure Activity
 # # Log for the specified subscription over the last 30 days and
-# # processes the results through the full pipeline.
+# # processes the results through the full pipeline. RoleSchema
+# # defaults to 'AzureRbac' (Activity Log is a schema-constrained
+# # source).
 #
 # .EXAMPLE
-# $objResult = & (Join-Path -Path $HOME -ChildPath 'repos/GloryRole/src/Invoke-RoleMiningPipeline.ps1') -InputMode LogAnalytics -WorkspaceId '12345678-1234-1234-1234-123456789012' -Start (Get-Date).AddDays(-30) -End (Get-Date) -OutputPath (Join-Path -Path $HOME -ChildPath 'output/role-mining')
+# $objResult = & (Join-Path -Path $HOME -ChildPath 'repos/GloryRole/src/Invoke-RoleMiningPipeline.ps1') -InputMode LogAnalytics -WorkspaceId '12345678-1234-1234-1234-123456789012' -RoleSchema AzureRbac -Start (Get-Date).AddDays(-30) -End (Get-Date) -OutputPath (Join-Path -Path $HOME -ChildPath 'output/role-mining')
 #
-# # Runs the pipeline in LogAnalytics mode. Queries the specified Log
-# # Analytics workspace for activity data over the last 30 days and
-# # processes the results through the full pipeline.
+# # Runs the pipeline in LogAnalytics mode with Azure RBAC output.
+# # LogAnalytics is schema-neutral (the same workspace can hold Azure
+# # Activity or Entra audit tables), so RoleSchema is required.
 #
 # .EXAMPLE
 # $objResult = & (Join-Path -Path $HOME -ChildPath 'repos/GloryRole/src/Invoke-RoleMiningPipeline.ps1') -InputMode EntraId -Start (Get-Date).AddDays(-30) -End (Get-Date) -OutputPath (Join-Path -Path $HOME -ChildPath 'output/entra-role-mining')
@@ -143,6 +180,8 @@
 # # Runs the pipeline in EntraId mode. Queries Microsoft Graph for
 # # Entra ID directory audit logs over the last 30 days, clusters
 # # admin activities, and generates Entra ID custom role definitions.
+# # RoleSchema defaults to 'EntraId' (Graph directory audit is a
+# # schema-constrained source).
 #
 # .NOTES
 # Supported PowerShell versions:
@@ -160,7 +199,7 @@
 # Position 1: OutputPath
 # All remaining parameters should be specified by name.
 #
-# Version: 1.7.20260415.2
+# Version: 1.8.20260415.0
 
 [CmdletBinding()]
 [OutputType([pscustomobject])]
@@ -171,6 +210,9 @@ param (
 
     [Parameter(Mandatory = $true)]
     [string]$OutputPath,
+
+    [ValidateSet('AzureRbac', 'EntraId')]
+    [string]$RoleSchema,
 
     [string]$CsvPath,
 
@@ -259,7 +301,42 @@ try {
 }
 
 try {
-    Write-Debug ("Parameters received: InputMode={0}, OutputPath={1}" -f $InputMode, $OutputPath)
+    # Resolve -RoleSchema using default-where-constrained semantics.
+    # Schema-constrained sources (ActivityLog, EntraId) default to the
+    # only role schema they can meaningfully produce. Schema-neutral
+    # sources (CSV, LogAnalytics) require the caller to state the
+    # schema explicitly; the tool does not default to a particular
+    # platform, so that CSV / LogAnalytics callers treating AzureRbac,
+    # EntraId (and future AwsIam / GcpIam / ActiveDirectory) as equal
+    # citizens are not silently routed to a default platform.
+    if (-not $PSBoundParameters.ContainsKey('RoleSchema')) {
+        switch ($InputMode) {
+            'ActivityLog' { $RoleSchema = 'AzureRbac' }
+            'EntraId' { $RoleSchema = 'EntraId' }
+            default {
+                throw ("RoleSchema is required when InputMode is '{0}'. Pass -RoleSchema 'AzureRbac' or -RoleSchema 'EntraId' to select which role-definition schema to emit." -f $InputMode)
+            }
+        }
+    } else {
+        # Compatibility check: schema-constrained sources reject
+        # incompatible RoleSchema values so the caller gets a clear
+        # error instead of silently producing a role-definition JSON
+        # that the target API would reject.
+        switch ($InputMode) {
+            'ActivityLog' {
+                if ($RoleSchema -ne 'AzureRbac') {
+                    throw ("RoleSchema '{0}' is incompatible with InputMode 'ActivityLog'. The Azure Activity Log cmdlet only produces Azure RBAC actions, so only -RoleSchema 'AzureRbac' is valid (or omit -RoleSchema to use the default)." -f $RoleSchema)
+                }
+            }
+            'EntraId' {
+                if ($RoleSchema -ne 'EntraId') {
+                    throw ("RoleSchema '{0}' is incompatible with InputMode 'EntraId'. Microsoft Graph directory audit logs only produce microsoft.directory/* actions, so only -RoleSchema 'EntraId' is valid (or omit -RoleSchema to use the default)." -f $RoleSchema)
+                }
+            }
+        }
+    }
+
+    Write-Debug ("Parameters received: InputMode={0}, RoleSchema={1}, OutputPath={2}" -f $InputMode, $RoleSchema, $OutputPath)
 
     # Principal display-name lookup built during ingestion. Maps
     # PrincipalKey (GUID / AppId) to a human-readable name (UPN for
@@ -576,8 +653,11 @@ try {
     [System.IO.File]::WriteAllText($strClustersPath, [string]$strClustersJson, $objUtf8NoBomEncoding)
     Write-Verbose ("  Exported: {0}" -f $strClustersPath)
 
-    # Role JSON per cluster
-    if ($InputMode -eq 'EntraId') {
+    # Role JSON per cluster. Gated on $RoleSchema (not $InputMode) so
+    # that schema-neutral sources (CSV, LogAnalytics) can emit either
+    # Azure RBAC or Entra ID role definitions based on the caller's
+    # explicit -RoleSchema choice.
+    if ($RoleSchema -eq 'EntraId') {
         # Entra ID custom role definitions (unifiedRoleDefinition format).
         foreach ($objCluster in $arrClusterActions) {
             $strRoleName = Get-EntraIdRoleDisplayName -ResourceActions $objCluster.Actions -ClusterId $objCluster.ClusterId -Prefix $EntraIdRoleNamePrefix

--- a/src/Invoke-RoleMiningPipeline.ps1
+++ b/src/Invoke-RoleMiningPipeline.ps1
@@ -199,16 +199,16 @@
 # Position 1: OutputPath
 # All remaining parameters should be specified by name.
 #
-# Version: 1.8.20260415.0
+# Version: 1.8.20260415.1
 
-[CmdletBinding()]
+[CmdletBinding(PositionalBinding = $false)]
 [OutputType([pscustomobject])]
 param (
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, Position = 0)]
     [ValidateSet('CSV', 'ActivityLog', 'LogAnalytics', 'EntraId')]
     [string]$InputMode,
 
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, Position = 1)]
     [string]$OutputPath,
 
     [ValidateSet('AzureRbac', 'EntraId')]

--- a/src/Invoke-RoleMiningPipeline.ps1
+++ b/src/Invoke-RoleMiningPipeline.ps1
@@ -194,12 +194,12 @@
 #   - macOS (PowerShell 7.x only)
 #   - Linux (PowerShell 7.x only)
 #
-# This script supports positional parameters in declaration order.
-# Position 0: InputMode
-# Position 1: OutputPath
-# All remaining parameters should be specified by name.
+# This script supports positional parameters:
+#   Position 0: InputMode
+#   Position 1: OutputPath
+# All other parameters must be specified by name.
 #
-# Version: 1.8.20260415.1
+# Version: 1.8.20260415.2
 
 [CmdletBinding(PositionalBinding = $false)]
 [OutputType([pscustomobject])]

--- a/tests/PowerShell/Invoke-RoleMiningPipeline.Tests.ps1
+++ b/tests/PowerShell/Invoke-RoleMiningPipeline.Tests.ps1
@@ -280,7 +280,7 @@ Describe "Invoke-RoleMiningPipeline" {
                 $objException | Should -Not -BeNullOrEmpty
                 $objException.Exception.Message | Should -Match "RoleSchema is required when InputMode is 'CSV'"
             } finally {
-                if (Test-Path -Path $strOutputPath) {
+                if (Test-Path -LiteralPath $strOutputPath) {
                     Remove-Item -LiteralPath $strOutputPath -Recurse -Force
                 }
             }
@@ -302,7 +302,7 @@ Describe "Invoke-RoleMiningPipeline" {
                 $objException | Should -Not -BeNullOrEmpty
                 $objException.Exception.Message | Should -Match "RoleSchema is required when InputMode is 'LogAnalytics'"
             } finally {
-                if (Test-Path -Path $strOutputPath) {
+                if (Test-Path -LiteralPath $strOutputPath) {
                     Remove-Item -LiteralPath $strOutputPath -Recurse -Force
                 }
             }
@@ -326,7 +326,7 @@ Describe "Invoke-RoleMiningPipeline" {
                 $objException | Should -Not -BeNullOrEmpty
                 $objException.Exception.Message | Should -Match "incompatible with InputMode 'ActivityLog'"
             } finally {
-                if (Test-Path -Path $strOutputPath) {
+                if (Test-Path -LiteralPath $strOutputPath) {
                     Remove-Item -LiteralPath $strOutputPath -Recurse -Force
                 }
             }
@@ -348,7 +348,7 @@ Describe "Invoke-RoleMiningPipeline" {
                 $objException | Should -Not -BeNullOrEmpty
                 $objException.Exception.Message | Should -Match "incompatible with InputMode 'EntraId'"
             } finally {
-                if (Test-Path -Path $strOutputPath) {
+                if (Test-Path -LiteralPath $strOutputPath) {
                     Remove-Item -LiteralPath $strOutputPath -Recurse -Force
                 }
             }
@@ -363,7 +363,7 @@ Describe "Invoke-RoleMiningPipeline" {
         }
 
         AfterAll {
-            if (Test-Path -Path $script:strEntraOutputPath) {
+            if (Test-Path -LiteralPath $script:strEntraOutputPath) {
                 Remove-Item -LiteralPath $script:strEntraOutputPath -Recurse -Force
             }
         }
@@ -373,12 +373,12 @@ Describe "Invoke-RoleMiningPipeline" {
         }
 
         It "Exports at least one entra_role_cluster_*.json file" {
-            $arrEntraRoleFiles = @(Get-ChildItem -Path $script:strEntraOutputPath -Filter 'entra_role_cluster_*.json')
+            $arrEntraRoleFiles = @(Get-ChildItem -LiteralPath $script:strEntraOutputPath -Filter 'entra_role_cluster_*.json')
             $arrEntraRoleFiles.Count | Should -BeGreaterThan 0
         }
 
         It "Does not export any Azure RBAC role_cluster_*.json files" {
-            $arrAzureRoleFiles = @(Get-ChildItem -Path $script:strEntraOutputPath -Filter 'role_cluster_*.json')
+            $arrAzureRoleFiles = @(Get-ChildItem -LiteralPath $script:strEntraOutputPath -Filter 'role_cluster_*.json')
             $arrAzureRoleFiles.Count | Should -Be 0
         }
     }

--- a/tests/PowerShell/Invoke-RoleMiningPipeline.Tests.ps1
+++ b/tests/PowerShell/Invoke-RoleMiningPipeline.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Invoke-RoleMiningPipeline" {
     Context "When running in CSV mode with sample data" {
         BeforeAll {
             $script:strOutputPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
-            $script:objResult = & $script:strScriptPath -InputMode CSV -CsvPath $script:strCsvPath -OutputPath $script:strOutputPath
+            $script:objResult = & $script:strScriptPath -InputMode CSV -CsvPath $script:strCsvPath -RoleSchema AzureRbac -OutputPath $script:strOutputPath
         }
 
         AfterAll {
@@ -111,7 +111,7 @@ Describe "Invoke-RoleMiningPipeline" {
             $strOutputPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
             try {
                 # Act / Assert
-                { & $script:strScriptPath -InputMode CSV -OutputPath $strOutputPath } | Should -Throw
+                { & $script:strScriptPath -InputMode CSV -RoleSchema AzureRbac -OutputPath $strOutputPath } | Should -Throw
             } finally {
                 if (Test-Path -Path $strOutputPath) {
                     Remove-Item -LiteralPath $strOutputPath -Recurse -Force
@@ -190,7 +190,7 @@ Describe "Invoke-RoleMiningPipeline" {
             # Act
             $objException = $null
             try {
-                & $script:strScriptPath -InputMode CSV -CsvPath $script:strPruneAllCsvPath -OutputPath $script:strPruneAllOutputPath
+                & $script:strScriptPath -InputMode CSV -CsvPath $script:strPruneAllCsvPath -RoleSchema AzureRbac -OutputPath $script:strPruneAllOutputPath
             } catch {
                 $objException = $_
             }
@@ -217,8 +217,8 @@ Describe "Invoke-RoleMiningPipeline" {
         BeforeAll {
             $script:strSeedOutputPath1 = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
             $script:strSeedOutputPath2 = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
-            $script:objSeedResult1 = & $script:strScriptPath -InputMode CSV -CsvPath $script:strCsvPath -OutputPath $script:strSeedOutputPath1 -Seed 42
-            $script:objSeedResult2 = & $script:strScriptPath -InputMode CSV -CsvPath $script:strCsvPath -OutputPath $script:strSeedOutputPath2 -Seed 42
+            $script:objSeedResult1 = & $script:strScriptPath -InputMode CSV -CsvPath $script:strCsvPath -RoleSchema AzureRbac -OutputPath $script:strSeedOutputPath1 -Seed 42
+            $script:objSeedResult2 = & $script:strScriptPath -InputMode CSV -CsvPath $script:strCsvPath -RoleSchema AzureRbac -OutputPath $script:strSeedOutputPath2 -Seed 42
         }
 
         AfterAll {
@@ -239,7 +239,7 @@ Describe "Invoke-RoleMiningPipeline" {
     Context "When verifying RecommendedK range" {
         BeforeAll {
             $script:strRangeOutputPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
-            $script:objRangeResult = & $script:strScriptPath -InputMode CSV -CsvPath $script:strCsvPath -OutputPath $script:strRangeOutputPath
+            $script:objRangeResult = & $script:strScriptPath -InputMode CSV -CsvPath $script:strCsvPath -RoleSchema AzureRbac -OutputPath $script:strRangeOutputPath
 
             # Count distinct principals in sample data for upper bound
             $arrCsvData = Import-Csv -Path $script:strCsvPath
@@ -260,6 +260,126 @@ Describe "Invoke-RoleMiningPipeline" {
         It "RecommendedK is less than or equal to the number of principals" {
             # Assert
             $script:objRangeResult.RecommendedK | Should -BeLessOrEqual $script:intPrincipalCount
+        }
+    }
+
+    Context "When resolving -RoleSchema for schema-neutral sources" {
+        It "Throws when -RoleSchema is omitted with InputMode CSV" {
+            # Arrange
+            $strOutputPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+            try {
+                # Act
+                $objException = $null
+                try {
+                    & $script:strScriptPath -InputMode CSV -CsvPath $script:strCsvPath -OutputPath $strOutputPath
+                } catch {
+                    $objException = $_
+                }
+
+                # Assert
+                $objException | Should -Not -BeNullOrEmpty
+                $objException.Exception.Message | Should -Match "RoleSchema is required when InputMode is 'CSV'"
+            } finally {
+                if (Test-Path -Path $strOutputPath) {
+                    Remove-Item -LiteralPath $strOutputPath -Recurse -Force
+                }
+            }
+        }
+
+        It "Throws when -RoleSchema is omitted with InputMode LogAnalytics" {
+            # Arrange
+            $strOutputPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+            try {
+                # Act
+                $objException = $null
+                try {
+                    & $script:strScriptPath -InputMode LogAnalytics -WorkspaceId 'w' -Start (Get-Date) -End (Get-Date) -OutputPath $strOutputPath
+                } catch {
+                    $objException = $_
+                }
+
+                # Assert
+                $objException | Should -Not -BeNullOrEmpty
+                $objException.Exception.Message | Should -Match "RoleSchema is required when InputMode is 'LogAnalytics'"
+            } finally {
+                if (Test-Path -Path $strOutputPath) {
+                    Remove-Item -LiteralPath $strOutputPath -Recurse -Force
+                }
+            }
+        }
+    }
+
+    Context "When validating -RoleSchema / -InputMode compatibility" {
+        It "Throws when -RoleSchema 'EntraId' is passed with InputMode ActivityLog" {
+            # Arrange
+            $strOutputPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+            try {
+                # Act
+                $objException = $null
+                try {
+                    & $script:strScriptPath -InputMode ActivityLog -RoleSchema EntraId -SubscriptionIds @('00000000-0000-0000-0000-000000000000') -Start (Get-Date) -End (Get-Date) -OutputPath $strOutputPath
+                } catch {
+                    $objException = $_
+                }
+
+                # Assert
+                $objException | Should -Not -BeNullOrEmpty
+                $objException.Exception.Message | Should -Match "incompatible with InputMode 'ActivityLog'"
+            } finally {
+                if (Test-Path -Path $strOutputPath) {
+                    Remove-Item -LiteralPath $strOutputPath -Recurse -Force
+                }
+            }
+        }
+
+        It "Throws when -RoleSchema 'AzureRbac' is passed with InputMode EntraId" {
+            # Arrange
+            $strOutputPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+            try {
+                # Act
+                $objException = $null
+                try {
+                    & $script:strScriptPath -InputMode EntraId -RoleSchema AzureRbac -Start (Get-Date) -End (Get-Date) -OutputPath $strOutputPath
+                } catch {
+                    $objException = $_
+                }
+
+                # Assert
+                $objException | Should -Not -BeNullOrEmpty
+                $objException.Exception.Message | Should -Match "incompatible with InputMode 'EntraId'"
+            } finally {
+                if (Test-Path -Path $strOutputPath) {
+                    Remove-Item -LiteralPath $strOutputPath -Recurse -Force
+                }
+            }
+        }
+    }
+
+    Context "When running in CSV mode with -RoleSchema EntraId against the Entra sample" {
+        BeforeAll {
+            $script:strEntraCsvPath = Join-Path -Path $strSamplesRoot -ChildPath 'entra_id_principal_action_counts.csv'
+            $script:strEntraOutputPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+            $script:objEntraResult = & $script:strScriptPath -InputMode CSV -CsvPath $script:strEntraCsvPath -RoleSchema EntraId -OutputPath $script:strEntraOutputPath
+        }
+
+        AfterAll {
+            if (Test-Path -Path $script:strEntraOutputPath) {
+                Remove-Item -LiteralPath $script:strEntraOutputPath -Recurse -Force
+            }
+        }
+
+        It "Returns a non-null result" {
+            $script:objEntraResult | Should -Not -BeNullOrEmpty
+        }
+
+        It "Exports at least one entra_role_cluster_*.json file" {
+            $arrEntraRoleFiles = @(Get-ChildItem -Path $script:strEntraOutputPath -Filter 'entra_role_cluster_*.json')
+            $arrEntraRoleFiles.Count | Should -BeGreaterThan 0
+        }
+
+        It "Does not export any Azure RBAC role_cluster_*.json files" {
+            $arrAzureRoleFiles = @(Get-ChildItem -Path $script:strEntraOutputPath -Filter 'role_cluster_*.json')
+            $arrAzureRoleFiles.Count | Should -Be 0
         }
     }
 }

--- a/tests/PowerShell/Invoke-RoleMiningPipeline.Tests.ps1
+++ b/tests/PowerShell/Invoke-RoleMiningPipeline.Tests.ps1
@@ -355,6 +355,64 @@ Describe "Invoke-RoleMiningPipeline" {
         }
     }
 
+    Context "When -RoleSchema is omitted for schema-constrained sources" {
+        # Locks in the defaulting contract: InputMode 'ActivityLog' defaults
+        # to RoleSchema 'AzureRbac' and InputMode 'EntraId' defaults to
+        # RoleSchema 'EntraId'. These invocations will still fail downstream
+        # (no Az / Microsoft.Graph context, fake subscription IDs, etc.),
+        # but the error must NOT be the RoleSchema-required error (defaulting
+        # must bypass that gate) nor a compatibility error. A regression that
+        # removes the defaults would surface as a failure here.
+
+        It "Does not throw a RoleSchema-related error when -RoleSchema is omitted with InputMode ActivityLog" {
+            # Arrange
+            $strOutputPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+            try {
+                # Act
+                $objException = $null
+                try {
+                    & $script:strScriptPath -InputMode ActivityLog -SubscriptionIds @('00000000-0000-0000-0000-000000000000') -Start (Get-Date) -End (Get-Date) -OutputPath $strOutputPath
+                } catch {
+                    $objException = $_
+                }
+
+                # Assert - any error raised must not be the RoleSchema gate
+                if ($null -ne $objException) {
+                    $objException.Exception.Message | Should -Not -Match "RoleSchema is required when InputMode is 'ActivityLog'"
+                    $objException.Exception.Message | Should -Not -Match "incompatible with InputMode 'ActivityLog'"
+                }
+            } finally {
+                if (Test-Path -LiteralPath $strOutputPath) {
+                    Remove-Item -LiteralPath $strOutputPath -Recurse -Force
+                }
+            }
+        }
+
+        It "Does not throw a RoleSchema-related error when -RoleSchema is omitted with InputMode EntraId" {
+            # Arrange
+            $strOutputPath = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.Guid]::NewGuid().ToString())
+            try {
+                # Act
+                $objException = $null
+                try {
+                    & $script:strScriptPath -InputMode EntraId -Start (Get-Date) -End (Get-Date) -OutputPath $strOutputPath
+                } catch {
+                    $objException = $_
+                }
+
+                # Assert - any error raised must not be the RoleSchema gate
+                if ($null -ne $objException) {
+                    $objException.Exception.Message | Should -Not -Match "RoleSchema is required when InputMode is 'EntraId'"
+                    $objException.Exception.Message | Should -Not -Match "incompatible with InputMode 'EntraId'"
+                }
+            } finally {
+                if (Test-Path -LiteralPath $strOutputPath) {
+                    Remove-Item -LiteralPath $strOutputPath -Recurse -Force
+                }
+            }
+        }
+    }
+
     Context "When running in CSV mode with -RoleSchema EntraId against the Entra sample" {
         BeforeAll {
             $script:strEntraCsvPath = Join-Path -Path $strSamplesRoot -ChildPath 'entra_id_principal_action_counts.csv'

--- a/tests/PowerShell/Invoke-RoleMiningPipeline.Tests.ps1
+++ b/tests/PowerShell/Invoke-RoleMiningPipeline.Tests.ps1
@@ -113,7 +113,7 @@ Describe "Invoke-RoleMiningPipeline" {
                 # Act / Assert
                 { & $script:strScriptPath -InputMode CSV -RoleSchema AzureRbac -OutputPath $strOutputPath } | Should -Throw
             } finally {
-                if (Test-Path -Path $strOutputPath) {
+                if (Test-Path -LiteralPath $strOutputPath) {
                     Remove-Item -LiteralPath $strOutputPath -Recurse -Force
                 }
             }
@@ -242,7 +242,7 @@ Describe "Invoke-RoleMiningPipeline" {
             $script:objRangeResult = & $script:strScriptPath -InputMode CSV -CsvPath $script:strCsvPath -RoleSchema AzureRbac -OutputPath $script:strRangeOutputPath
 
             # Count distinct principals in sample data for upper bound
-            $arrCsvData = Import-Csv -Path $script:strCsvPath
+            $arrCsvData = Import-Csv -LiteralPath $script:strCsvPath
             $script:intPrincipalCount = ($arrCsvData | Select-Object -Property PrincipalKey -Unique).Count
         }
 


### PR DESCRIPTION
## Description

This PR introduces the `-RoleSchema` parameter to `Invoke-RoleMiningPipeline.ps1`, decoupling the data source (`-InputMode`) from the role-definition schema emitted in output artifacts. This enables schema-neutral sources (CSV, LogAnalytics) to produce either Azure RBAC or Entra ID custom role definitions based on explicit caller intent, rather than silently defaulting to a single platform.

### Key Changes

- **New `-RoleSchema` parameter** with values `AzureRbac` and `EntraId`
  - Required for schema-neutral sources (`CSV`, `LogAnalytics`)
  - Defaults to `AzureRbac` for `ActivityLog` (schema-constrained)
  - Defaults to `EntraId` for `EntraId` (schema-constrained)
  - Incompatible combinations fail fast with actionable errors

- **Artifact naming now schema-aware**
  - `AzureRbac` → `role_cluster_<id>.json`
  - `EntraId` → `entra_role_cluster_<id>.json`

- **Updated documentation** with examples for both schemas and migration guidance for the breaking change

- **Comprehensive test coverage** including:
  - Required `-RoleSchema` validation for schema-neutral sources
  - Incompatibility checks for schema-constrained sources
  - New test context for Entra ID CSV mode with sample data

## Type of Change

- [x] Breaking change (schema-neutral sources now require explicit `-RoleSchema`)
- [x] New feature (role schema selection for CSV/LogAnalytics)
- [x] Documentation update

## Checklist

### General

- [x] My code follows the coding standards in `.github/instructions/`
- [x] I have commented my code where necessary (role schema resolution logic)
- [x] I have made corresponding changes to the documentation (README, help text, requirements)
- [x] I have added or updated tests where appropriate (4 new test contexts)
- [x] New and existing tests pass locally

### PowerShell-Specific

- [x] PSScriptAnalyzer passes locally
- [x] Pester tests pass locally (all existing tests updated to pass `-RoleSchema`, new tests added)
- [x] PowerShell formatting follows repository standards (OTBS)

## Migration Notes

**Breaking change in 1.8:** Existing `CSV` or `LogAnalytics` invocations must now explicitly pass `-RoleSchema AzureRbac` (for previous behavior) or `-RoleSchema EntraId` (for Entra custom roles). `ActivityLog` and `EntraId` invocations are unaffected (defaults apply). This change ensures the tool does not silently assume a default platform for schema-neutral inputs, which would not extend cleanly as additional role schemas (AWS IAM, GCP IAM, Active Directory) are added.

## Related Issues

Closes #

https://claude.ai/code/session_01H3J9DSyX9nY2SbLfeui5w5